### PR TITLE
add XProc 3.0 tutorial, remove typo

### DIFF
--- a/src/learning.md
+++ b/src/learning.md
@@ -20,10 +20,12 @@ Introductory learning materials about XProc 3.0:
 * Articles:
   * [An Introduction to XProc 3.0](https://www.xml.com/articles/2019/11/05/introduction-xproc-30/) (Erik&#160;Siegel on [xml.com](https://www.xml.com/))
   * [XProc 3.0 - Connecting steps using ports](https://www.xml.com/articles/2020/01/23/xproc-30-connecting-steps-using-ports/) (Erik&#160;Siegel on [xml.com](https://www.xml.com/))
+* Tutorials:
+  * [XProc 3.0 Tutorial](https://xporc.net/xproc-tutorial/) (Martin&#160;Kraetke on [xporc.net](https://xporc.net))
 * Conference proceedings:
   * [XProc 3.0](https://www.balisage.net/Proceedings/vol23/html/Walsh02/BalisageVol23-Walsh02.html) (Norman&#160;Tovey-Walsh and Achim&#160;Berndzen at [Balisage](https://www.balisage.net/) 2019)
 * Recorded conference talks:
-  * [Introduction to XProc 3.0](https://www.youtube.com/watch?v=P5fnBnJhUGA) ((Erik&#160;Siegel at [Declarative Amsterdam](https://declarative.amsterdam/) 2021)
+  * [Introduction to XProc 3.0](https://www.youtube.com/watch?v=P5fnBnJhUGA) (Erik&#160;Siegel at [Declarative Amsterdam](https://declarative.amsterdam/) 2021)
   * [XProc 3.0: Ready or Not](https://youtu.be/Q42bhIbSYLk) (Norman&#160;Tovey-Walsh at [XML Prague](https://www.xmlprague.cz/) 2020)
 * Webinars:
   * [XProc 3.0 101 - Part 1](https://youtu.be/g_ockOvU57U) (Erik&#160;Siegel at [Markup UK](https://markupuk.org/) 2020)


### PR DESCRIPTION
I would be glad if you would add my XProc 3.0 tutorial which I wrote recently to xproc.org. There are still more articles to come on more advanced XProc topics, but it covers enough lessons for a fresh start with XProc 3.0.